### PR TITLE
AWS Deploy - Skip deploy steps if keys aren't present

### DIFF
--- a/.github/workflows/aws-cloud-deploy.yml
+++ b/.github/workflows/aws-cloud-deploy.yml
@@ -60,6 +60,7 @@ jobs:
     env:
       aws_access_secret: ${{ secrets.AWS_ACCESS_KEY_ID }}
       cloud_aws_access_secret: ${{ secrets.CLOUD_AWS_ACCESS_KEY_ID }}
+      opsdesk_api_client_id: ${{ secrets.OPSDESK_API_CLIENT_ID }}
     # Map the job outputs to step outputs
     outputs:
       container-build-tag: ${{ steps.build-container.outputs.container-build-tag }}
@@ -177,5 +178,5 @@ jobs:
 
       - name: Upload Brightspot version
         if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
-        run: ./brightspot/analysis/opsdesk-post.sh brightspot-version/brightspot-version.txt ./etc/container/docker-metadata.json ${{ secrets.OPSDESK_API_CLIENT_ID }} ${{ secrets.OPSDESK_API_SECRET }}
+        run: ./brightspot/analysis/opsdesk-post.sh brightspot-version/brightspot-version.txt ./etc/container/docker-metadata.json ${{ env.opsdesk_api_client_id }} ${{ secrets.OPSDESK_API_SECRET }}
         shell: bash

--- a/.github/workflows/aws-cloud-deploy.yml
+++ b/.github/workflows/aws-cloud-deploy.yml
@@ -57,7 +57,7 @@ jobs:
   build:
     name: "AWS Cloud Deploy"
     runs-on: ${{ inputs.runs-on }}
-    if: github.actor!= 'dependabot[bot]'   # ignore dependabot
+    if: ${{ secrets.AWS_ACCESS_KEY_ID || secrets.CLOUD_AWS_ACCESS_KEY_ID }}  # ignore deploys with no keys
     # Map the job outputs to step outputs
     outputs:
       container-build-tag: ${{ steps.build-container.outputs.container-build-tag }}

--- a/.github/workflows/aws-cloud-deploy.yml
+++ b/.github/workflows/aws-cloud-deploy.yml
@@ -57,7 +57,9 @@ jobs:
   build:
     name: "AWS Cloud Deploy"
     runs-on: ${{ inputs.runs-on }}
-    if: ${{ secrets.AWS_ACCESS_KEY_ID || secrets.CLOUD_AWS_ACCESS_KEY_ID }}  # ignore deploys with no keys
+    env:
+      aws_access_secret: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      cloud_aws_access_secret: ${{ secrets.CLOUD_AWS_ACCESS_KEY_ID }}
     # Map the job outputs to step outputs
     outputs:
       container-build-tag: ${{ steps.build-container.outputs.container-build-tag }}
@@ -83,7 +85,7 @@ jobs:
           echo "GITHUB_ACTIONS_PULL_REQUEST=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
 
       - name: Deploy to S3
-        if: ${{ inputs.deploy-s3 }}
+        if: ${{ inputs.deploy-s3 && env.aws_access_secret != '' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -97,7 +99,7 @@ jobs:
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
-        if: ${{ inputs.deploy-container }}
+        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
         with:
           aws-access-key-id: ${{ secrets.CLOUD_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CLOUD_AWS_SECRET_ACCESS_KEY }}
@@ -105,27 +107,27 @@ jobs:
           aws-region: ${{ inputs.region }}
 
       - name: ECR
-        if: ${{ inputs.deploy-container }}
+        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
         run: | 
           echo "Project ECR - ${{ vars.PROJECT_AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.region }}.amazonaws.com" 
           echo "Brightspot Cloud ECR - ${{ vars.CLOUD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.region }}.amazonaws.com"
 
       - name: Login to project ECR
         uses: docker/login-action@v3
-        if: ${{ inputs.deploy-container }}
+        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
         with:
             registry: ${{ vars.PROJECT_AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.region }}.amazonaws.com
 
       - name: Login to Brightspot Cloud ECR
         uses: docker/login-action@v3
-        if: ${{ inputs.deploy-container }}
+        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
         with:
             registry: ${{ vars.CLOUD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.region }}.amazonaws.com
 
 
       - name: Build Container
         id: build-container
-        if: ${{ inputs.deploy-container }}
+        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
         shell: bash
         run: |
           version=""
@@ -174,6 +176,6 @@ jobs:
           path: brightspot-version
 
       - name: Upload Brightspot version
-        if: ${{ inputs.deploy-container }}
+        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
         run: ./brightspot/analysis/opsdesk-post.sh brightspot-version/brightspot-version.txt ./etc/container/docker-metadata.json ${{ secrets.OPSDESK_API_CLIENT_ID }} ${{ secrets.OPSDESK_API_SECRET }}
         shell: bash

--- a/.github/workflows/aws-cloud-deploy.yml
+++ b/.github/workflows/aws-cloud-deploy.yml
@@ -177,6 +177,6 @@ jobs:
           path: brightspot-version
 
       - name: Upload Brightspot version
-        if: ${{ inputs.deploy-container && env.cloud_aws_access_secret != '' }}
-        run: ./brightspot/analysis/opsdesk-post.sh brightspot-version/brightspot-version.txt ./etc/container/docker-metadata.json ${{ env.opsdesk_api_client_id }} ${{ secrets.OPSDESK_API_SECRET }}
+        if: ${{ inputs.deploy-container && env.opsdesk_api_client_id != '' }}
+        run: ./brightspot/analysis/opsdesk-post.sh brightspot-version/brightspot-version.txt ./etc/container/docker-metadata.json ${{  secrets.OPSDESK_API_CLIENT_ID }} ${{ secrets.OPSDESK_API_SECRET }}
         shell: bash


### PR DESCRIPTION
Remove Dependabot check in favor of check for keys.