### PR TITLE
Add environment variables to brightspot-build workflow

### DIFF
--- a/.github/workflows/brightspot-build.yml
+++ b/.github/workflows/brightspot-build.yml
@@ -52,6 +52,25 @@ on:
         type: string
         default: ubuntu-20.04-4core
 
+      env1Name:
+        description: Name for environment variable #1
+        type: string
+      env1Value:
+        description: Value for environment variable #1
+        type: string
+      env2Name:
+        description: Name for environment variable #2
+        type: string
+      env2Value:
+        description: Value for environment variable #2
+        type: string
+      env3Name:
+        description: Name for environment variable #3
+        type: string
+      env3Value:
+        description: Value for environment variable #3
+        type: string
+
     secrets:
       GRADLE_CACHE_USERNAME:
         required: false
@@ -67,6 +86,18 @@ jobs:
       container-build-tag: ${{ steps.build-container.outputs.container-build-tag }}
       container-version-tag: ${{ steps.build-container.outputs.container-version-tag }}
     steps:
+      - name: Set Environment Variables
+        run: |
+          if [ -n "${{ inputs.env1Name }}" ]; then
+            echo "${{ inputs.env1Name }}=${{ inputs.env1Value }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ inputs.env2Name }}" ]; then
+            echo "${{ inputs.env2Name }}=${{ inputs.env2Value }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ inputs.env3Name }}" ]; then
+            echo "${{ inputs.env3Name }}=${{ inputs.env3Value }}" >> $GITHUB_ENV
+          fi
+
       - uses: actions/checkout@v4
 
       - name: Setup Node

--- a/.github/workflows/brightspot-build.yml
+++ b/.github/workflows/brightspot-build.yml
@@ -53,25 +53,22 @@ on:
         default: ubuntu-20.04-4core
 
       env1Name:
-        description: Name for environment variable #1
-        type: string
-      env1Value:
-        description: Value for environment variable #1
+        description: Name for environment variable #1 (value is passed via secrets)
         type: string
       env2Name:
-        description: Name for environment variable #2
-        type: string
-      env2Value:
-        description: Value for environment variable #2
+        description: Name for environment variable #2 (value is passed via secrets)
         type: string
       env3Name:
-        description: Name for environment variable #3
-        type: string
-      env3Value:
-        description: Value for environment variable #3
+        description: Name for environment variable #3 (value is passed via secrets)
         type: string
 
     secrets:
+      ENV_1_VALUE:
+        required: false
+      ENV_2_VALUE:
+        required: false
+      ENV_3_VALUE:
+        required: false
       GRADLE_CACHE_USERNAME:
         required: false
       GRADLE_CACHE_PASSWORD:
@@ -89,13 +86,13 @@ jobs:
       - name: Set Environment Variables
         run: |
           if [ -n "${{ inputs.env1Name }}" ]; then
-            echo "${{ inputs.env1Name }}=${{ inputs.env1Value }}" >> $GITHUB_ENV
+            echo "${{ inputs.env1Name }}=${{ secrets.ENV_1_VALUE }}" >> $GITHUB_ENV
           fi
           if [ -n "${{ inputs.env2Name }}" ]; then
-            echo "${{ inputs.env2Name }}=${{ inputs.env2Value }}" >> $GITHUB_ENV
+            echo "${{ inputs.env2Name }}=${{ secrets.ENV_2_VALUE }}" >> $GITHUB_ENV
           fi
           if [ -n "${{ inputs.env3Name }}" ]; then
-            echo "${{ inputs.env3Name }}=${{ inputs.env3Value }}" >> $GITHUB_ENV
+            echo "${{ inputs.env3Name }}=${{ secrets.ENV_3_VALUE }}" >> $GITHUB_ENV
           fi
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Reusable workflows don't inherit the environment they're called from so there needs to be an explicit input on the workflow for any needed variables