### PR TITLE
Fix issue that occurred when s3api --format=text added a column.

### DIFF
--- a/aws/aws-s3-deploy.sh
+++ b/aws/aws-s3-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 set -eu
 

--- a/aws/aws-s3-deploy.sh
+++ b/aws/aws-s3-deploy.sh
@@ -105,7 +105,7 @@ then
         number_of_items=`aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json --query="length(Contents[])"` || number_of_items=0
         echo "$number_of_items items in $DEPLOY_BUCKET/$cleanup_prefix$suffix/..."
         
-        aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json | jq -r '[.Contents[] | .LastModified, .Key] | @tsv' \
+        aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json | jq -r '[.Contents[] | .LastModified, .Key] | @tsv' | \
         while read -r line
         do
             last_modified=`echo "$line" | cut -f1"

--- a/aws/aws-s3-deploy.sh
+++ b/aws/aws-s3-deploy.sh
@@ -72,10 +72,9 @@ if ! [ -x "$(command -v aws)" ]; then
     export PATH=~/.local/bin:$PATH
 fi
 
-aws s3api list-objects --bucket $DEPLOY_BUCKET --prefix $target --output=text | \
-while read -r line
+aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $target --output=json | jq -r '.Contents[] | .Key' | \
+while read -r filename
 do
-    filename=`echo "$line" | awk -F'\t' '{print $3}'`
     if [[ $filename != "" && $filename != "None" ]]
     then
         echo "Deleting existing artifact s3://$DEPLOY_BUCKET/$filename."
@@ -103,22 +102,20 @@ then
         # track number of items in the bucket to ensure we don't delete everything, which would break the _deploy servlet
         item_count=0
         echo "Getting number of items in $DEPLOY_BUCKET with prefix $cleanup_prefix$suffix/..."
-        number_of_items=`aws s3api list-objects --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json --query="length(Contents[])"` || number_of_items=0
+        number_of_items=`aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json --query="length(Contents[])"` || number_of_items=0
         echo "$number_of_items items in $DEPLOY_BUCKET/$cleanup_prefix$suffix/..."
         
-        aws s3api list-objects --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=text | \
+        aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json | jq -r '[.Contents[] | .LastModified, .Key] | @tsv' \
         while read -r line
         do
-            echo "s3api line = $line"
-            last_modified=`echo "$line" | awk -F'\t' '{print $4}'`
-            echo "s3api last_modified: $last_modified"
+            last_modified=`echo "$line" | cut -f1"
             if [[ -z $last_modified ]]
             then
                 continue
             fi
             item_count=$((item_count+1))
             last_modified_ts=`date -d"$last_modified" +%s`
-            filename=`echo "$line" | awk -F'\t' '{print $3}'`
+            filename=`echo "$line" | cut -f2"
             echo "File # $item_count: $filename. Last modified: $last_modified_ts"
             if [[ $last_modified_ts -lt $older_than_ts ]]
             then

--- a/aws/aws-s3-deploy.sh
+++ b/aws/aws-s3-deploy.sh
@@ -108,14 +108,14 @@ then
         aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json | jq -r '[.Contents[] | .LastModified, .Key] | @tsv' | \
         while read -r line
         do
-            last_modified=`echo "$line" | cut -f1"`
+            last_modified=`echo "$line" | cut -f1`
             if [[ -z $last_modified ]]
             then
                 continue
             fi
             item_count=$((item_count+1))
             last_modified_ts=`date -d"$last_modified" +%s`
-            filename=`echo "$line" | cut -f2"
+            filename=`echo "$line" | cut -f2`
             echo "File # $item_count: $filename. Last modified: $last_modified_ts"
             if [[ $last_modified_ts -lt $older_than_ts ]]
             then

--- a/aws/aws-s3-deploy.sh
+++ b/aws/aws-s3-deploy.sh
@@ -108,7 +108,7 @@ then
         aws s3api list-objects-v2 --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=json | jq -r '[.Contents[] | .LastModified, .Key] | @tsv' | \
         while read -r line
         do
-            last_modified=`echo "$line" | cut -f1"
+            last_modified=`echo "$line" | cut -f1"`
             if [[ -z $last_modified ]]
             then
                 continue

--- a/aws/aws-s3-deploy.sh
+++ b/aws/aws-s3-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -eu
 
@@ -109,7 +109,9 @@ then
         aws s3api list-objects --bucket $DEPLOY_BUCKET --prefix $cleanup_prefix$suffix/ --output=text | \
         while read -r line
         do
+            echo "s3api line = $line"
             last_modified=`echo "$line" | awk -F'\t' '{print $4}'`
+            echo "s3api last_modified: $last_modified"
             if [[ -z $last_modified ]]
             then
                 continue


### PR DESCRIPTION
CONTENTS        "3cab0a6dee7d365b219103e33c43295a-18"   builds/xxx/pull-request/1716/xxx-site-PR1716.war        2025-01-24T17:11:20+00:00       147171519       STANDARD

vs. 

CONTENTS	FULL_OBJECT	"3cab0a6dee7d365b219103e33c43295a-18"	builds/xxx/pull-request/1716/xxx-site-PR1716.war	2025-01-24T17:11:20+00:00	147171519	STANDARD

The "FULL_OBJECT" column was added at some point, which broke our parsing of that line. This PR changes it to use the JSON format instead, which should be more stable.