### PR TITLE
Make timeout configurable

### DIFF
--- a/.github/workflows/aws-cloud-deploy.yml
+++ b/.github/workflows/aws-cloud-deploy.yml
@@ -82,6 +82,12 @@ on:
         type: string
         default: ''
 
+      container-build-timeout:
+        description: 'Timeout in minutes for container build jobs'
+        required: false
+        type: number
+        default: 10
+
     secrets:
       AWS_ACCESS_KEY_ID:
         required: false
@@ -104,7 +110,7 @@ jobs:
   build-x86-container:
     name: "Build x86 Container"
     runs-on: ${{ inputs.runs-on }}
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.container-build-timeout }}
     env:
       aws_access_secret: ${{ secrets.AWS_ACCESS_KEY_ID }}
       cloud_aws_access_secret: ${{ secrets.CLOUD_AWS_ACCESS_KEY_ID }}
@@ -265,7 +271,7 @@ jobs:
   build-arm-container:
     name: "Build ARM Container"
     runs-on: ${{ inputs.runs-on-arm }}
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.container-build-timeout }}
     env:
       aws_access_secret: ${{ secrets.AWS_ACCESS_KEY_ID }}
       cloud_aws_access_secret: ${{ secrets.CLOUD_AWS_ACCESS_KEY_ID }}
@@ -414,7 +420,7 @@ jobs:
     name: "Build Container Manifest"
     if: ${{ inputs.deploy-container }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: ${{ inputs.container-build-timeout }}
     env:
       aws_access_secret: ${{ secrets.AWS_ACCESS_KEY_ID }}
       cloud_aws_access_secret: ${{ secrets.CLOUD_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Multiple Amazon projects started timing out due to the recently added 10m timeout:

https://github.com/perfectsense/amazon-autos/actions/runs/21455991116/job/61797506722
https://github.com/perfectsense/amazon-shippingfreight/actions/runs/21482980118/job/61884925837

When this happens it blocks all development / testing.

Not sure why this started happening now. However, it's not surprising it's only affecting Amazon (to my knowledge) because we build ImageMagick from source (https://github.com/perfectsense/amazon-pvt-docs/pull/127) in each build (I was able to mitigate the timeout problem by excluding unneeded ImageMagick features, but it would also be nice to have an out.)

Test previously succeeding build with a short timeout to force it to fail: https://github.com/perfectsense/amazon-pvt-docs/pull/127
Test previously failing build with a long timeout to let it succeed: https://github.com/perfectsense/amazon-pvt-docs/pull/128
