### PR TITLE
ci: add reusable workflow for PR title validation

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -3,8 +3,8 @@ name: PR Title Check
 on:
   workflow_call:
     inputs:
-      jira-project:
-        description: 'The Jira project key (e.g., BSP)'
+      jira-projects:
+        description: 'Jira project key(s) separated by pipe for multiple (e.g., "BSP" or "BSP|BSPGO")'
         required: true
         type: string
 
@@ -21,5 +21,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          subjectPattern: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') && !startsWith(github.event.pull_request.title, 'chore:') && !startsWith(github.event.pull_request.title, 'ci:') && !startsWith(github.event.pull_request.title, 'docs:') && !startsWith(github.event.pull_request.title, 'style:') && format('(^|.+\\s){0}-\\d+(\\s.+|$)', inputs.jira-project) || '' }}"
-          subjectPatternError: "PR title must contain a reference to one or more ${{ inputs.jira-project }} work items in Jira."
+          subjectPattern: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') && !startsWith(github.event.pull_request.title, 'chore:') && !startsWith(github.event.pull_request.title, 'ci:') && !startsWith(github.event.pull_request.title, 'docs:') && !startsWith(github.event.pull_request.title, 'style:') && format('(^|.+\\s)({0})-\\d+(\\s.+|$)', inputs.jira-projects) || '' }}"
+          subjectPatternError: "PR title must contain a reference to one or more ${{ inputs.jira-projects }} work items in Jira."

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,10 +9,12 @@ on:
         type: string
 
 jobs:
-  title:
-    name: Title
+  title-check:
+    name: PR Title Check
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: read
     steps:
       - name: Check the PR title against the Conventional Commits spec
         uses: amannn/action-semantic-pull-request@v6

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,23 @@
+name: PR Title Check
+
+on:
+  workflow_call:
+    inputs:
+      jira-project:
+        description: 'The Jira project key (e.g., BSP)'
+        required: true
+        type: string
+
+jobs:
+  title:
+    name: Title
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the PR title against the Conventional Commits spec
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: "${{ !contains(github.event.pull_request.labels.*.name, 'autorelease: pending') && !startsWith(github.event.pull_request.title, 'chore:') && !startsWith(github.event.pull_request.title, 'ci:') && !startsWith(github.event.pull_request.title, 'docs:') && !startsWith(github.event.pull_request.title, 'style:') && format('(^|.+\\s){0}-\\d+(\\s.+|$)', inputs.jira-project) || '' }}"
+          subjectPatternError: "PR title must contain a reference to one or more ${{ inputs.jira-project }} work items in Jira."

--- a/README.md
+++ b/README.md
@@ -23,6 +23,52 @@ builds/exampleco/pull-request/15/exampleco-1.0-SNAPSHOT.war
 builds/exampleco/pull-request/15/exampleco-1.0-SNAPSHOT.zip
 ```
 
+## PR Title Check
+
+This workflow validates that PR titles follow the [Conventional Commits](https://www.conventionalcommits.org/) specification and include a Jira ticket reference.
+
+### Features
+- Enforces conventional commit format (e.g., `feat:`, `fix:`, `chore:`)
+- Requires Jira ticket reference in the PR title (e.g., `BSP-123`)
+- Supports multiple Jira project keys
+- Skips Jira validation for `chore:`, `ci:`, `docs:`, and `style:` prefixes
+- Skips validation for draft PRs and auto-release PRs
+
+### Inputs
+| Input | Required | Description |
+|-------|----------|-------------|
+| `jira-projects` | Yes | Jira project key(s). Use pipe separator for multiple keys (e.g., `"BSP"` or `"BSP\|BSPGO"`) |
+
+### Example Usage
+```yaml
+name: PR Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  title:
+    name: Title
+    uses: perfectsense/brightspot-github-actions-workflows/.github/workflows/pr-title-check.yml@v2
+    with:
+      jira-projects: BSPGO
+```
+
+For multiple Jira projects:
+```yaml
+jobs:
+  title:
+    name: Title
+    uses: perfectsense/brightspot-github-actions-workflows/.github/workflows/pr-title-check.yml@v2
+    with:
+      jira-projects: BSP|BSPGO
+```
+
 ## Usage
 
 Variables used below:


### PR DESCRIPTION
Validates PR titles follow conventional commits and include Jira ticket reference.