### PR TITLE
feat: make ai-review-claude reusable via workflow_call

### DIFF
--- a/.github/workflows/ai-review-claude.yml
+++ b/.github/workflows/ai-review-claude.yml
@@ -1,19 +1,35 @@
 name: AI Review (Claude)
 
-on:
-  push:
-    branches:
-      - develop
-      - main
-      - release/*
-    tags: v*
+# Reusable Claude PR-review workflow. Call it from another repository:
+#
+#     name: AI Review (Claude)
+#
+#     on:
+#       pull_request:
+#         types: [opened, synchronize, reopened, ready_for_review]
+#
+#     permissions:
+#       contents: read
+#       pull-requests: write
+#       id-token: write
+#
+#     jobs:
+#       review:
+#         uses: perfectsense/brightspot-github-actions-workflows/.github/workflows/ai-review-claude.yml@v1
+#         secrets: inherit
 
+on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - develop
-      - main
-      - release/*
+
+  workflow_call:
+    secrets:
+      ANTHROPIC_API_KEY:
+        required: false
+      JIRA_EMAIL:
+        required: false
+      JIRA_API_TOKEN:
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/ai-review-claude.yml
+++ b/.github/workflows/ai-review-claude.yml
@@ -50,24 +50,79 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Detect Jira project from Autolink settings
-        id: autolink
-        run: |
-          DETECTED=$(gh api repos/${{ github.repository }}/autolinks \
-            --jq '[.[].key_prefix | select(test("^[A-Z]+-$"))] | first // ""' \
-            | sed 's/-$//')
-          echo "jira-project=${DETECTED:-BSP}" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
-
+      # Jira context is optional: when the Jira secrets are unavailable, the
+      # review still runs — it just can't evaluate the PR against the work item.
       - name: Fetch the Jira work item
         id: jira
-        uses: perfectsense/.github/jira-context@main
+        uses: actions/github-script@v7
+        env:
+          JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         with:
-          project: ${{ steps.autolink.outputs.jira-project }}
-          email: ${{ secrets.JIRA_EMAIL }}
-          api-token: ${{ secrets.JIRA_API_TOKEN }}
-          text: ${{ github.event.pull_request.title }}
+          script: |
+            core.setOutput('context', '');
+
+            const email = process.env.JIRA_EMAIL;
+            const apiToken = process.env.JIRA_API_TOKEN;
+
+            if (!email || !apiToken) {
+              core.notice('Jira credentials are not configured; reviewing without Jira context.');
+              return;
+            }
+
+            // Detect the Jira project from the repo's Autolink settings,
+            // defaulting to BSP when none is configured.
+            let prefix = 'BSP-';
+            try {
+              const { data: autolinks } = await github.rest.repos.listAutolinks(context.repo);
+              const detected = autolinks.map(a => a.key_prefix).find(p => /^[A-Z]+-$/.test(p));
+              if (detected) prefix = detected;
+            } catch (error) {
+              core.warning(`Could not read Autolink settings: ${error.message}`);
+            }
+
+            const pattern = new RegExp(`${prefix}\\d+`, 'g');
+            const keys = [...new Set([...(process.env.PR_TITLE || '').matchAll(pattern)].map(m => m[0]))];
+            if (keys.length === 0) {
+              return;
+            }
+
+            const auth = Buffer.from(`${email}:${apiToken}`).toString('base64');
+            const results = [];
+
+            for (const key of keys) {
+              const response = await fetch(
+                `https://perfectsense.atlassian.net/rest/api/3/issue/${key}?fields=summary,description,status,comment`,
+                { headers: { 'Authorization': `Basic ${auth}`, 'Accept': 'application/json' } }
+              );
+
+              if (!response.ok) {
+                core.warning(`Failed to fetch Jira work item ${key}: ${response.status} ${response.statusText}`);
+                continue;
+              }
+
+              const { fields } = await response.json();
+              results.push({
+                key,
+                summary: fields.summary,
+                description: fields.description,
+                status: fields.status?.name,
+                comments: (fields.comment?.comments || []).map(c => ({
+                  author: c.author?.displayName,
+                  body: c.body,
+                  created: c.created
+                }))
+              });
+            }
+
+            if (results.length > 0) {
+              core.setOutput(
+                'context',
+                'Use the following context from Jira to evaluate whether the PR fulfills the requirements:\n'
+                  + JSON.stringify(results)
+              );
+            }
 
       - name: Review the code
         uses: anthropics/claude-code-action@v1
@@ -98,7 +153,6 @@ jobs:
             - Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues
             - Only post GitHub comments - don't submit review text as messages
 
-            Use the following context from Jira to evaluate whether the PR fulfills the requirements:
             ${{ steps.jira.outputs.context }}
             
             After posting any inline comments or top-level feedback:


### PR DESCRIPTION
Adds a workflow_call trigger (with optional secret declarations so callers can pass secrets explicitly when not using `secrets: inherit`) and a usage example. Direct trigger narrowed to pull_request only, on all branches.